### PR TITLE
Remove redirect after add friend

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -29,7 +29,7 @@ class FriendshipsController < ApplicationController
       flash[:alert] = 'Something went wrong...'
     end
 
-    redirect_to dashboard_path
+   # redirect_to dashboard_path (remove comment if you want to redirect back to your dashboard)
   end
 
   def destroy

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -22,7 +22,9 @@ class FriendshipsController < ApplicationController
       recipient_friendship = Friendship.new(sender: User.find(params[:user]), recipient: User.find(current_user.id), status: "pending")
     end
 
-      outcome = sender_friendship.save && recipient_friendship.save
+
+    outcome = sender_friendship.save && recipient_friendship.save
+
     if outcome
       flash[:notice] = 'You now have a new friend!'
     else
@@ -30,6 +32,8 @@ class FriendshipsController < ApplicationController
     end
 
    # redirect_to dashboard_path (remove comment if you want to redirect back to your dashboard)
+   redirect_back(fallback_location: dashboard_path)
+
   end
 
   def destroy


### PR DESCRIPTION
After you add a friend, you no longer go back to your dashboard, you stay on the page. However I made it so that the page refreshes, so that the friends button disappears and the friends added alert does appear.

pinging @akellos @greentea-latte @missevia for review